### PR TITLE
com.amazon.coral.service#SerializationException 例外を回避

### DIFF
--- a/src/ddb.erl
+++ b/src/ddb.erl
@@ -152,7 +152,7 @@ typed_attribute({Key, Value}) ->
 typed_value(Value) when is_binary(Value) ->
     [{<<"S">>, Value}];
 typed_value(Value) when is_integer(Value) ->
-    [{<<"N">>, Value}].
+    [{<<"N">>, integer_to_binary(Value)}].
 
 
 -spec list_tables(#ddb_config{}) -> [binary()].


### PR DESCRIPTION
put_item 時, ドキュメントの要素に数値型が含まれると, DynamoDB 側で com.amazon.coral.service#SerializationException 例外が発生するため, 対処しました.

scan 対応で, 関数をまとめたことによる障害です.